### PR TITLE
docs(ecosystem): add Thymeleaf Shiro Dialect to Community section

### DIFF
--- a/ecosystem.html
+++ b/ecosystem.html
@@ -489,6 +489,21 @@
 					</p>
 				</section>
 
+				<section class="subsection">
+					<header>
+						<h3>
+							<a id="thymeleaf-shiro-dialect" href="#thymeleaf-shiro-dialect" class="anchor"></a>
+							Thymeleaf Shiro Dialect
+						</h3>
+					</header>
+					<p class="community-authors">by Thebora Kompanioni</p>
+					<p><a href="https://github.com/theborakompanioni/thymeleaf-extras-shiro">https://github.com/theborakompanioni/thymeleaf-extras-shiro</a></p>
+
+					<p>
+						A Thymeleaf dialect for Apache Shiro tags.
+					</p>
+				</section>
+
 			</section>
 
 			<section>


### PR DESCRIPTION
docs(ecosystem): add Thymeleaf Shiro Dialect to Community section

Adds "Thymeleaf Shiro Dialect" in the "Community Dialect" section of the Ecosystem page.
Source: https://github.com/theborakompanioni/thymeleaf-extras-shiro

```html
<section class="subsection">
	<header>
		<h3>
			<a id="thymeleaf-shiro-dialect" href="#thymeleaf-shiro-dialect" class="anchor"></a>
			Thymeleaf Shiro Dialect
		</h3>
	</header>
	<p class="community-authors">by Thebora Kompanioni</p>
	<p><a href="https://github.com/theborakompanioni/thymeleaf-extras-shiro">https://github.com/theborakompanioni/thymeleaf-extras-shiro</a></p>

	<p>
		A Thymeleaf dialect for Apache Shiro tags.
	</p>
</section>
```