### PR TITLE
Adding link to Thymeleaf CLI project in Community Tools

### DIFF
--- a/ecosystem.html
+++ b/ecosystem.html
@@ -728,6 +728,19 @@
 					rapid development of resources in separate module files).</p>
 				</section>
 
+				<section class="subsection">
+					<header>
+						<h3>
+							<a id="thymeleaf-cli" href="#thymeleaf-cli" class="anchor"></a>
+							Thymeleaf CLI
+						</h3>
+					</header>
+					<p class="community-authors">by Motofix</p>
+					<p><a href="https://framagit.org/motofix/thymeleaf-cli">https://framagit.org/motofix/thymeleaf-cli</a></p>
+
+					<p>Command-line tool that can be used as HTML Preprocessor for static websites.</p>
+				</section>
+
 			</section>
 
 			<section>


### PR DESCRIPTION
Adding an entry in "ecosystem / community tools" to the Thymeleaf CLI  project, a command-line tool that can be used as HTML Preprocessor for static websites